### PR TITLE
Collaborative user playlists

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ name: Deploy
 on:
   push:
     branches:
-      - main
+      - final_project
 
 jobs:
   build:

--- a/routes/api/playlist.js
+++ b/routes/api/playlist.js
@@ -91,7 +91,9 @@ router.put('/toggle', express.json(), async function(req,res) {
         },
         data: {
             "name": "Weekly releases from Spotify Release Tracker",
-            "description": "Your weekly releases, tracked and created from Spotify Release Tracker"
+            "description": "Your weekly releases, tracked and created from Spotify Release Tracker",
+            "public": false,
+            "collaborative": true
         }
         }).then(response => {
           let addedPlaylistID = response.data.id;


### PR DESCRIPTION
Change the default populated playlist to be collaborative, so that the server can easily update a user's playlist with tracked releases